### PR TITLE
Unlock pydantic version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ include = ["LICENSE.md"]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-pydantic = "2.5.3"
+pydantic = "^2.5.3"
 importlib_metadata = { version = ">=4", python = "<3.8" }
 typing_extensions = { version = ">=4", python = "<3.8" }
 pydantic-settings = "^2.1.0"


### PR DESCRIPTION
This library freezes pydantic to version 2.5.3, which is a major no no.

It's well accept protocol not to lock in versions of dependencies, but rather to specify lax lower bounds you're confident will vaguely work. I'm not sure what that version is but I'll assume it's 2.5.3 see as that's what it's been set as.

The reason is that anyone (today, that's me) upgrading a large project to pydantic v2 will be unable to do so if one of its dependencies requires pydantic > 2.5.3, all because someone used `pydantic2-argparse` in one small corner of the project even if that's barely used, because of the way poetry checks version compatibility.